### PR TITLE
Negate the soft delete query by default 

### DIFF
--- a/flask_common/documents.py
+++ b/flask_common/documents.py
@@ -79,9 +79,9 @@ class NotDeletedQuerySet(QuerySet):
     def __call__(self, q_obj=None, class_check=True, slave_okay=False, read_preference=None, include_deleted=False, **query):
         if not include_deleted:
             if q_obj:
-                q_obj &= Q(is_deleted=False)
+                q_obj &= Q(is_deleted__ne=True)
             else:
-                q_obj = Q(is_deleted=False)
+                q_obj = Q(is_deleted__ne=True)
         return super(NotDeletedQuerySet, self).__call__(q_obj, class_check, slave_okay, read_preference, **query)
 
 class SoftDeleteDocument(Document):


### PR DESCRIPTION
So objects with None are considered to exist. That way no migration is necessary to make existing classes soft deletable.
