### PR TITLE
Replace blist.sortedset dependence with sortedcontainers.SortedSet

### DIFF
--- a/flask_common/fields.py
+++ b/flask_common/fields.py
@@ -2,7 +2,7 @@ import re
 import pytz
 import phonenumbers
 from bson import Binary
-from blist import sortedset
+from sortedcontainers import SortedSet
 from mongoengine.fields import StringField, BinaryField, ListField, EmailField
 
 from flask.ext.common.utils import isortedset
@@ -83,7 +83,7 @@ class SortedSetField(ListField):
     """
 
     _key = None
-    set_class = sortedset
+    set_class = SortedSet
 
     def __init__(self, field, **kwargs):
         if 'key' in kwargs.keys():

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ phonenumbers
 pycrypto
 padding
 Unidecode
+sortedcontainers


### PR DESCRIPTION
The sortedcontainers implementation of SortedSet is [faster](http://www.grantjenks.com/docs/sortedcontainers/performance.html#id10) than blist's for the pattern used below. The constructor is very fast. [SortedContainers](http://www.grantjenks.com/docs/sortedcontainers/) is also pure-Python which makes deployment and hacking easier.
