### PR TITLE
Easier comparisons for unit tests

### DIFF
--- a/flask_common/test_helpers.py
+++ b/flask_common/test_helpers.py
@@ -1,4 +1,5 @@
 from freezegun import freeze_time
+import re
 
 class FreezeTimeMixin():
     """
@@ -25,4 +26,49 @@ class FreezeTimeMixin():
             self.freezer.stop()
             self.frozen = False
 
+class SetCompare(object):
+    """
+    Comparator that doesn't take ordering into account. For example, the
+    following expression is True:
 
+    SetCompare([1, 2, 3]) == [2, 3, 1]
+    """
+    def __init__(self, members):
+        self.members = members
+
+    def __eq__(self, other):
+        return set(other) == set(self.members)
+
+class RegexSetCompare(object):
+    """
+    Comparator that tages a regex and a set of arguments and doesn't take
+    ordering of the arguments into account. For example, the following
+    expression is True:
+
+    RegexSetCompare('(.*) OR (.*) OR (.*)', ['1', '2', '3']) == '2 OR 3 OR 1'
+    """
+    def __init__(self, regex, args):
+        self.regex = re.compile(regex)
+        self.args = args
+
+    def __eq__(self, other):
+        match = self.regex.match(other)
+        if not match:
+            return False
+        return set(match.groups()) == set(self.args)
+
+class Capture(object):
+    """
+    Comparator that always returns True and returns the captured object when
+    called. For example:
+
+    capture = Capture()
+    capture == 'Hello'  # returns True
+    capture()           # returns 'Hello'
+    """
+    def __call__(self):
+        return self.obj
+
+    def __eq__(self, other):
+        self.obj = other
+        return True

--- a/flask_common/test_helpers.py
+++ b/flask_common/test_helpers.py
@@ -41,7 +41,7 @@ class SetCompare(object):
 
 class RegexSetCompare(object):
     """
-    Comparator that tages a regex and a set of arguments and doesn't take
+    Comparator that takes a regex and a set of arguments and doesn't take
     ordering of the arguments into account. For example, the following
     expression is True:
 


### PR DESCRIPTION
This makes it easier for tests to do comparisons where the order doesn't matter, e.g.:

```
capture_msg = Capture()

self.assertEqual(imap_log, [
    ('search', RegexSetCompare('OR HEADER Message-ID (.*) HEADER Message-ID (.*)',
               ['expected_msgid1', 'expected_msgid2']),
    ('fetch', SetCompare([1, 2]),
    ('append', capture_msg),
])

appended_msg = capture_msg()
self.assertTrue('some string' in appended_msg)
```