### PR TITLE
Explicitly autogenerate ID for IDField

### DIFF
--- a/flask_common/fields/id.py
+++ b/flask_common/fields/id.py
@@ -17,10 +17,14 @@ class IDField(UUIDField):
 
     IDs are prefixed with the prefix (given to the constructor), followed by an
     underscore, followed by the zbase62-encoded ID.
+
+    If autogenerate=True is passed to the constructor, a random ID is generated
+    and assigned to the field by default.
     """
     def __init__(self, **kwargs):
         self.prefix = kwargs.pop('prefix')
-        if 'default' not in kwargs:
+        self.autogenerate = kwargs.pop('autogenerate', False)
+        if self.autogenerate:
             kwargs['default'] = self.generate_id
         super(IDField, self).__init__(**kwargs)
 

--- a/flask_common/fields/id.py
+++ b/flask_common/fields/id.py
@@ -25,6 +25,8 @@ class IDField(UUIDField):
         self.prefix = kwargs.pop('prefix')
         self.autogenerate = kwargs.pop('autogenerate', False)
         if self.autogenerate:
+            if 'default' in kwargs:
+                raise RuntimeError('Can\'t use "default" with "autogenerate"')
             kwargs['default'] = self.generate_id
         super(IDField, self).__init__(**kwargs)
 


### PR DESCRIPTION
Instead of implicitly generating a random ID for `IDField`, we'll require setting `autogenerate=True`. The most common use case is referencing an existing field, and implicitly generating IDs easily leads to unexpected issues.