### PR TITLE
Avoid caching in Mongo QuerySet

### DIFF
--- a/flask_common/documents.py
+++ b/flask_common/documents.py
@@ -438,3 +438,18 @@ class ForbiddenQueriesQuerySet(QuerySet):
                 query_shape[key] = 1
         return query_shape
 
+
+def iter_no_cache(query_set):
+    """Iterate over queryset without caching it.
+
+    Useful for iterating over large result sets / bulk actions.
+
+    If a batch size is not set, apply a sensible default of 1000
+    that's better than what Mongo server is doing (101 first and
+    then as many as it can fit in 4MB) to avoid cursor timeouts.
+    """
+    if query_set._batch_size is None:
+        query_set = query_set.batch_size(1000)
+
+    while True:
+        yield query_set.next()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,14 +12,15 @@ from flask import Flask
 from mongoengine import connection, Document
 from mongoengine.errors import DoesNotExist
 from mongoengine.fields import ReferenceField, SafeReferenceField, \
-                               SafeReferenceListField, StringField
+                               SafeReferenceListField, StringField, \
+                               IntField
 from werkzeug.datastructures import MultiDict
 from wtforms import Form
 
 from flask.ext.mongoengine import MongoEngine, ValidationError
 from flask_common.crypto import aes_generate_key
 from flask_common.declenum import DeclEnum
-from flask_common.documents import fetch_related
+from flask_common.documents import fetch_related, iter_no_cache
 from flask_common.utils import apply_recursively, isortedset, slugify, custom_query_counter, uniqify
 from flask_common.fields import PhoneField, TimezoneField, TrimmedStringField, \
                                 EncryptedStringField, LowerStringField, LowerEmailField
@@ -796,6 +797,41 @@ class DeclEnumTestCase(unittest.TestCase):
 
         db_type = TestEnum.db_type()
         self.assertEqual(db_type.enum.values(), ['alpha_value', 'beta_value'])
+
+
+class IterNoCacheTestCase(unittest.TestCase):
+    def test_no_cache(self):
+        import weakref
+
+        def is_cached(qs):
+            iterator = iter(qs)
+            d = next(iterator)
+            self.assertEqual(d.i, 0)
+            w = weakref.ref(d)
+            d = next(iterator)
+            self.assertEqual(d.i, 1)
+            # - If the weak reference is still valid at this point, then
+            #   iterator or queryset is holding onto the first object
+            # - Hold reference to qs until very end just in case
+            #   Python gets smart enough to destroy it
+            return w() is not None and qs is not None
+
+        class D(db.Document):
+            i = IntField()
+            pass
+
+        D.drop_collection()
+
+        for i in range(10):
+            D(i=i).save()
+
+        self.assertTrue(is_cached(D.objects.all()))
+        self.assertFalse(is_cached(iter_no_cache(D.objects.all())))
+
+        # check for correct exit behavior
+        self.assertEqual({d.i for d in iter_no_cache(D.objects.all())}, set(range(10)))
+        self.assertEqual({d.i for d in iter_no_cache(D.objects.all().batch_size(5))}, set(range(10)))
+        self.assertEqual({d.i for d in iter_no_cache(D.objects.order_by('i').limit(1))}, set(range(1)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Just a simple helper to avoid unintended caching in mongoengine querysets.