### PR TITLE
Add DictCompare test helper + test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.pytest_cache
 
 #Translations
 *.mo

--- a/circle.yml
+++ b/circle.yml
@@ -10,3 +10,8 @@ dependencies:
     - if [[ ! -d "custom_mongodb" ]]; then wget http://downloads.mongodb.org/linux/mongodb-linux-x86_64-${MONGO_VERSION}.tgz && tar xvzf mongodb-linux-x86_64-${MONGO_VERSION}.tgz && mv mongodb-linux-x86_64-${MONGO_VERSION} custom_mongodb; fi
     - sudo cp custom_mongodb/bin/* /usr/bin
     - sudo /etc/init.d/mongodb start
+
+test:
+  override:
+    - pyenv global 2.7.12 3.4.4 3.5.3 3.6.2
+    - tox

--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,3 @@
-machine:
-  environment:
-    MONGO_VERSION: 3.0.7
-
-dependencies:
-  cache_directories:
-    - custom_mongodb
-  pre:
-    - sudo /etc/init.d/mongodb stop
-    - if [[ ! -d "custom_mongodb" ]]; then wget http://downloads.mongodb.org/linux/mongodb-linux-x86_64-${MONGO_VERSION}.tgz && tar xvzf mongodb-linux-x86_64-${MONGO_VERSION}.tgz && mv mongodb-linux-x86_64-${MONGO_VERSION} custom_mongodb; fi
-    - sudo cp custom_mongodb/bin/* /usr/bin
-    - sudo /etc/init.d/mongodb start
-
 test:
   override:
     - pyenv global 2.7.12 3.4.4 3.5.3 3.6.2

--- a/flask_common/test_helpers.py
+++ b/flask_common/test_helpers.py
@@ -15,7 +15,7 @@ class SetCompare(object):
         return set(other) == set(self.members)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
 
 class RegexSetCompare(object):
@@ -37,7 +37,7 @@ class RegexSetCompare(object):
         return set(match.groups()) == set(self.args)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other
 
 
 class Capture(object):
@@ -77,4 +77,4 @@ class DictCompare(dict):
         return True
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not self == other

--- a/flask_common/test_helpers.py
+++ b/flask_common/test_helpers.py
@@ -46,3 +46,22 @@ class Capture(object):
     def __eq__(self, other):
         self.obj = other
         return True
+
+class DictCompare(dict):
+    """
+    Comparator that returns True if all the items in the comparator's dict are
+    contained in the other dict and match values, ignoring keys that are in the
+    other dict only.
+
+	For example, the following is true:
+    DictCompare({'a': 'b'}) == {'a': 'b', 'c': 'd'}
+
+	But the following are false:
+    DictCompare({'a': 'b'}) == {'a': 'c'}
+    DictCompare({'a': 'b'}) == {'b': 'c'}
+    """
+    def __eq__(self, other):
+        for k, v in self.items():
+            if not k in other or other[k] != v:
+                return False
+        return True

--- a/flask_common/test_helpers.py
+++ b/flask_common/test_helpers.py
@@ -1,5 +1,6 @@
 import re
 
+
 class SetCompare(object):
     """
     Comparator that doesn't take ordering into account. For example, the
@@ -12,6 +13,10 @@ class SetCompare(object):
 
     def __eq__(self, other):
         return set(other) == set(self.members)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class RegexSetCompare(object):
     """
@@ -31,6 +36,10 @@ class RegexSetCompare(object):
             return False
         return set(match.groups()) == set(self.args)
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
 class Capture(object):
     """
     Comparator that always returns True and returns the captured object when
@@ -47,16 +56,17 @@ class Capture(object):
         self.obj = other
         return True
 
+
 class DictCompare(dict):
     """
     Comparator that returns True if all the items in the comparator's dict are
     contained in the other dict and match values, ignoring keys that are in the
     other dict only.
 
-	For example, the following is true:
+    For example, the following is true:
     DictCompare({'a': 'b'}) == {'a': 'b', 'c': 'd'}
 
-	But the following are false:
+    But the following are false:
     DictCompare({'a': 'b'}) == {'a': 'c'}
     DictCompare({'a': 'b'}) == {'b': 'c'}
     """
@@ -65,3 +75,6 @@ class DictCompare(dict):
             if not k in other or other[k] != v:
                 return False
         return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flask==0.10.1
 -e git+ssh://git@github.com/closeio/mongoengine.git@b62ad0226336d6db39c85ce2cff49aeb94cc919e#egg=mongoengine-dev
 -e git+ssh://git@github.com/closeio/flask-mongoengine.git@0c2cc30ec98154bb2eb4499efada65239050025d#egg=flask-mongoengine
 Flask-SQLAlchemy==2.1
-phonenumbers==8.9.2
+phonenumbers==8.8.7
 pycrypto==2.6.1
 padding==0.4
 Unidecode==0.4.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ phonenumbers==7.2.6
 pycrypto==2.6.1
 padding==0.4
 Unidecode==0.4.19
-zbase62==1.2.0
-pyutil==2.0.0
+-e git+ssh://git@github.com/closeio/zbase62.git@e13d2c748ccdb0cafe6465961a0c6a4111ee219f#egg=zbase62
 flask-mail==0.9.1
 pymongo==2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flask==0.10.1
 -e git+ssh://git@github.com/closeio/mongoengine.git@b62ad0226336d6db39c85ce2cff49aeb94cc919e#egg=mongoengine-dev
 -e git+ssh://git@github.com/closeio/flask-mongoengine.git@0c2cc30ec98154bb2eb4499efada65239050025d#egg=flask-mongoengine
 Flask-SQLAlchemy==2.1
-phonenumbers==7.2.6
+phonenumbers==8.9.2
 pycrypto==2.6.1
 padding==0.4
 Unidecode==0.4.19

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     ],
     packages=find_packages(),
     test_suite='tests',
-    tests_require=['python-dateutil', 'pytz', 'flask', 'mongoengine', 'pycrypto', 'padding', ]
+    tests_require=['python-dateutil', 'pytz', 'flask', 'mongoengine', 'pycrypto', 'padding', 'pytest']
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+if sys.version_info[0] > 2:
+    collect_ignore = ['test_legacy.py']

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -780,7 +780,7 @@ class DeclEnumTestCase(unittest.TestCase):
         assert TestEnum.from_string('alpha_value') == TestEnum.alpha
 
         db_type = TestEnum.db_type()
-        self.assertEqual(db_type.enum.values(), ['alpha_value', 'beta_value'])
+        self.assertEqual(set(db_type.enum.values()), set(['alpha_value', 'beta_value']))
 
 
 class IterNoCacheTestCase(unittest.TestCase):
@@ -820,4 +820,3 @@ class IterNoCacheTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_test_helpers.py
+++ b/tests/test_test_helpers.py
@@ -1,0 +1,28 @@
+from flask_common.test_helpers import (
+    Capture, DictCompare, RegexSetCompare, SetCompare
+)
+
+
+def test_set_compare():
+    assert SetCompare([1, 2, 3]) == [2, 3, 1]
+    assert not (SetCompare([1, 2, 3]) == [2, 2, 2])
+
+
+def test_regex_set_compare():
+    regex = '(.*) OR (.*) OR (.*)'
+    assert RegexSetCompare(regex, ['1', '2', '3']) == '2 OR 3 OR 1'
+    assert not (RegexSetCompare(regex, ['2', '2', '2']) == '2 OR 3 OR 1')
+
+
+def test_capture():
+	capture = Capture()
+	assert capture == 'hello'
+	assert capture() == 'hello'
+
+
+def test_dict_compare():
+	assert {'a': 'b'} == DictCompare({'a': 'b'})
+	assert not ({'a': 'c'} == DictCompare({'a': 'b'}))
+	assert {'a': 'b', 'c': 'd'} == DictCompare({'a': 'b'})
+	assert not ({'a': 'c', 'c': 'd'} == DictCompare({'a': 'b'}))
+	assert not ({'a': 'b'} == DictCompare({'c': 'd'}))

--- a/tests/test_test_helpers.py
+++ b/tests/test_test_helpers.py
@@ -3,9 +3,16 @@ from flask_common.test_helpers import (
 )
 
 
+# Note we're using "not" instead of "!=" for comparisons here since the latter
+# uses __ne__, which is not implemented.
+
+
 def test_set_compare():
     assert SetCompare([1, 2, 3]) == [2, 3, 1]
     assert not (SetCompare([1, 2, 3]) == [2, 2, 2])
+
+    assert not (SetCompare([1, 2, 3]) != [2, 3, 1])
+    assert SetCompare([1, 2, 3]) != [2, 2, 2]
 
 
 def test_regex_set_compare():
@@ -13,16 +20,25 @@ def test_regex_set_compare():
     assert RegexSetCompare(regex, ['1', '2', '3']) == '2 OR 3 OR 1'
     assert not (RegexSetCompare(regex, ['2', '2', '2']) == '2 OR 3 OR 1')
 
+    assert not (RegexSetCompare(regex, ['1', '2', '3']) != '2 OR 3 OR 1')
+    assert RegexSetCompare(regex, ['2', '2', '2']) != '2 OR 3 OR 1'
+
 
 def test_capture():
-	capture = Capture()
-	assert capture == 'hello'
-	assert capture() == 'hello'
+    capture = Capture()
+    assert capture == 'hello'
+    assert capture() == 'hello'
 
 
 def test_dict_compare():
-	assert {'a': 'b'} == DictCompare({'a': 'b'})
-	assert not ({'a': 'c'} == DictCompare({'a': 'b'}))
-	assert {'a': 'b', 'c': 'd'} == DictCompare({'a': 'b'})
-	assert not ({'a': 'c', 'c': 'd'} == DictCompare({'a': 'b'}))
-	assert not ({'a': 'b'} == DictCompare({'c': 'd'}))
+    assert DictCompare({'a': 'b'}) == {'a': 'b'}
+    assert not (DictCompare({'a': 'b'}) == {'a': 'c'})
+    assert DictCompare({'a': 'b'}) == {'a': 'b', 'c': 'd'}
+    assert not (DictCompare({'a': 'b'}) == {'a': 'c', 'c': 'd'})
+    assert not (DictCompare({'c': 'd'}) == {'a': 'b'})
+
+    assert not (DictCompare({'a': 'b'}) != {'a': 'b'})
+    assert DictCompare({'a': 'b'}) != {'a': 'c'}
+    assert not (DictCompare({'a': 'b'}) != {'a': 'b', 'c': 'd'})
+    assert DictCompare({'a': 'b'}) != {'a': 'c', 'c': 'd'}
+    assert DictCompare({'c': 'd'}) != {'a': 'b'}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py34,py35,py36
+
+[testenv]
+commands=pytest {posargs}
+deps=-rrequirements.txt
+     pytest


### PR DESCRIPTION
Added `DictCompare`, which I plan to use in certain dialer tests.

Tests on Circle are now executed using pytest on Trusty, and we test new things with both py2/3 (but I moved all previous tests to `test_legacy.py` until we split them out).