### PR TITLE
Better Enum performance

### DIFF
--- a/flask_common/enum.py
+++ b/flask_common/enum.py
@@ -13,13 +13,23 @@ class Enum(object):
     is prone to typos.
     """
 
+    # Cached values and choices to avoid introspection on every call.
+    __values = []
+    __choices = []
+
     @classmethod
     def values(cls):
         """
         Returns a list of all the values, e.g.: ('choice1', 'choice2')
         """
-        return [getattr(cls,v) for v in dir(cls)
-                if not callable(getattr(cls,v)) and not v.startswith('_')]
+        if not cls.__values:
+            cls.__values = [
+                getattr(cls,v)
+                for v in dir(cls)
+                if not callable(getattr(cls,v)) and not v.startswith('_')
+            ]
+
+        return cls.__values
 
     @classmethod
     def choices(cls):
@@ -27,5 +37,11 @@ class Enum(object):
         Returns a list of choice tuples, e.g.:
         [('value1', 'Choice1'), ('value2', 'Choice2')]
         """
-        return [(getattr(cls,v), v) for v in dir(cls)
-                if not callable(getattr(cls,v)) and not v.startswith('_')]
+        if not cls.__choices:
+            cls.__choices = [
+                (getattr(cls,v), v)
+                for v in dir(cls)
+                if not callable(getattr(cls,v)) and not v.startswith('_')
+            ]
+
+        return cls.__choices

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,0 +1,13 @@
+from flask_common.enum import Enum
+
+class TestEnum(Enum):
+    A = 'a'
+    B = 'b'
+
+
+def test_enum():
+    # Fetch twice to ensure cache is correct
+    assert TestEnum.values() == ['a', 'b']
+    assert TestEnum.values() == ['a', 'b']
+    assert TestEnum.choices() == [('a', 'A'), ('b', 'B')]
+    assert TestEnum.choices() == [('a', 'A'), ('b', 'B')]


### PR DESCRIPTION
This caches `values` and `choices` so we're not doing introspection and string checking on every call.