### PR TITLE
Remove flask-mail

### DIFF
--- a/flask_common/utils/__init__.py
+++ b/flask_common/utils/__init__.py
@@ -30,8 +30,6 @@ try:
         json_list_generator,
         lazylist,
         localtoday,
-        mail_admins,
-        mail_exception,
         make_unaware,
         parse_date_tz,
         returns_xml,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ pycrypto==2.6.1
 padding==0.4
 Unidecode==0.4.19
 -e git+ssh://git@github.com/closeio/zbase62.git@e13d2c748ccdb0cafe6465961a0c6a4111ee219f#egg=zbase62
-flask-mail==0.9.1
 pymongo==3.4.0


### PR DESCRIPTION
This removes flask-mail which appears abandoned 5 years ago and not very python3-compatible.

As a consequence, this also removes `mail_admins` and `mail_exception` methods.
- `mail_admins` is a convenience helper which doesn't really add much value. Just write your own that fits your needs if you want one.
- `mail_exception` is of limited usefulness as it causes a lot of collateral damage like filling your inbox in case an exception occurs very often. It doesn't work well with unicode either. Use specialized exception [reporting services](https://stackshare.io/exception-monitoring) instead.