### PR TITLE
Swap out pycrypto

### DIFF
--- a/flask_common/crypto.py
+++ b/flask_common/crypto.py
@@ -4,12 +4,12 @@ from Crypto.Util import Counter
 import hashlib
 import hmac
 
-AES_BLOCK_SIZE = 32  # 256 bit
-IV_SIZE = 16
-HMAC_KEY_SIZE = 32
+AES_KEY_SIZE = 32  # bytes
+HMAC_KEY_SIZE = 32  # bytes
+IV_SIZE = 16  # bytes
 HMAC_DIGEST = hashlib.sha256
 HMAC_DIGEST_SIZE = hashlib.sha256().digest_size
-KEY_LENGTH = AES_BLOCK_SIZE + HMAC_KEY_SIZE
+KEY_LENGTH = AES_KEY_SIZE + HMAC_KEY_SIZE
 
 V2_MARKER = b'v2'
 
@@ -48,8 +48,8 @@ def aes_decrypt(key, data, force_v1=False):
         data = data[IV_SIZE:]
         is_v2 = True
     else:
-        iv = data[:AES_BLOCK_SIZE]
-        data = data[AES_BLOCK_SIZE:]
+        iv = data[:AES_KEY_SIZE]
+        data = data[AES_KEY_SIZE:]
         is_v2 = False
     return aes_decrypt_iv(key, data, iv, is_v2)
 
@@ -57,8 +57,8 @@ def aes_decrypt(key, data, force_v1=False):
 # Encrypt + sign using no IV or provided IV. Pass empty string for no IV.
 # Note: You should normally use aes_encrypt()
 def aes_encrypt_iv(key, data, iv):
-    aes_key = key[:AES_BLOCK_SIZE]
-    hmac_key = key[AES_BLOCK_SIZE:]
+    aes_key = key[:AES_KEY_SIZE]
+    hmac_key = key[AES_KEY_SIZE:]
     initial_value = long(iv.encode("hex"), 16) if iv else 1
     ctr = Counter.new(128, initial_value=initial_value)
     cipher = AES.new(aes_key, AES.MODE_CTR, counter=ctr).encrypt(data)
@@ -69,8 +69,8 @@ def aes_encrypt_iv(key, data, iv):
 # Verify + decrypt using no IV or provided IV. Pass empty string for no IV.
 # Note: You should normally use aes_decrypt()
 def aes_decrypt_iv(key, data, iv, is_v2):
-    aes_key = key[:AES_BLOCK_SIZE]
-    hmac_key = key[AES_BLOCK_SIZE:]
+    aes_key = key[:AES_KEY_SIZE]
+    hmac_key = key[AES_KEY_SIZE:]
     sig_size = HMAC_DIGEST_SIZE
     cipher = data[:-sig_size]
     sig = data[-sig_size:]

--- a/flask_common/crypto.py
+++ b/flask_common/crypto.py
@@ -5,10 +5,13 @@ import hashlib
 import hmac
 
 AES_BLOCK_SIZE = 32  # 256 bit
+IV_SIZE = 16
 HMAC_KEY_SIZE = 32
 HMAC_DIGEST = hashlib.sha256
 HMAC_DIGEST_SIZE = hashlib.sha256().digest_size
 KEY_LENGTH = AES_BLOCK_SIZE + HMAC_KEY_SIZE
+
+V2_MARKER = b'v2'
 
 rng = Random.new().read
 
@@ -32,16 +35,23 @@ def aes_generate_key():
 # Encrypt + sign using a random IV
 def aes_encrypt(key, data):
     assert len(key) == KEY_LENGTH, 'invalid key size'
-    iv = rng(AES_BLOCK_SIZE)
-    return iv + aes_encrypt_iv(key, data, iv)
+    iv = rng(IV_SIZE)
+    return V2_MARKER + iv + aes_encrypt_iv(key, data, iv)
 
 
 # Verify + decrypt data encrypted with IV
-def aes_decrypt(key, data):
+def aes_decrypt(key, data, force_v1=False):
     assert len(key) == KEY_LENGTH, 'invalid key size'
-    iv = data[:AES_BLOCK_SIZE]
-    data = data[AES_BLOCK_SIZE:]
-    return aes_decrypt_iv(key, data, iv)
+    if not force_v1 and data.startswith(V2_MARKER):
+        data = data[len(V2_MARKER) :]
+        iv = data[:IV_SIZE]
+        data = data[IV_SIZE:]
+        is_v2 = True
+    else:
+        iv = data[:AES_BLOCK_SIZE]
+        data = data[AES_BLOCK_SIZE:]
+        is_v2 = False
+    return aes_decrypt_iv(key, data, iv, is_v2)
 
 
 # Encrypt + sign using no IV or provided IV. Pass empty string for no IV.
@@ -58,15 +68,21 @@ def aes_encrypt_iv(key, data, iv):
 
 # Verify + decrypt using no IV or provided IV. Pass empty string for no IV.
 # Note: You should normally use aes_decrypt()
-def aes_decrypt_iv(key, data, iv):
+def aes_decrypt_iv(key, data, iv, is_v2):
     aes_key = key[:AES_BLOCK_SIZE]
     hmac_key = key[AES_BLOCK_SIZE:]
     sig_size = HMAC_DIGEST_SIZE
     cipher = data[:-sig_size]
     sig = data[-sig_size:]
-    if hmac.new(hmac_key, iv + cipher, HMAC_DIGEST).digest() != sig:
-        raise AuthenticationError('message authentication failed')
+    try:
+        if hmac.new(hmac_key, iv + cipher, HMAC_DIGEST).digest() != sig:
+            raise AuthenticationError('message authentication failed')
+    except AuthenticationError:
+        if not is_v2:
+            raise
+        return aes_decrypt(key, V2_MARKER + iv + data, force_v1=True)
+    if not is_v2:
+        iv = iv[len(iv) / 2 :]
     initial_value = long(iv.encode("hex"), 16) if iv else 1
     ctr = Counter.new(128, initial_value=initial_value)
-    plain = AES.new(aes_key, AES.MODE_CTR, counter=ctr).decrypt(cipher)
-    return plain
+    return AES.new(aes_key, AES.MODE_CTR, counter=ctr).decrypt(cipher)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flask==0.10.1
 -e git+ssh://git@github.com/closeio/flask-mongoengine.git@0c2cc30ec98154bb2eb4499efada65239050025d#egg=flask-mongoengine
 Flask-SQLAlchemy==2.1
 phonenumbers==8.8.7
-pycrypto==2.6.1
+pycryptodome==3.9.0
 padding==0.4
 Unidecode==0.4.19
 -e git+ssh://git@github.com/closeio/zbase62.git@e13d2c748ccdb0cafe6465961a0c6a4111ee219f#egg=zbase62

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,31 @@
+from flask_common.crypto import aes_encrypt, aes_decrypt, aes_generate_key
+
+
+def test_new_decrypt_function_can_process_old_data():
+    data = 'test'
+
+    # These were generated using the old encrypt functions.
+    # We make sure the new functions can still decypher the old
+    # encrypted data.
+    key = b"\xe6\xb53\x90\xb8\x8f'-=e\x86z\xc3\x90\xff\xb8*\xf5\xd9\xaf\xb8\xad\x81\xcadl\xed\xf4\t\xe8\x9c*\r\x16\xd2\x00/\xd8\x86@)\xc1\x9b\x8d\xabo\xf7E\xbc\xf8\xae@\x98O\xf0\xd8[\xd0\xe1\x9a\xf5w\x03r"
+    encrypted_data = b'o\x15\n\xef\x9a\xd62\x86\x81\x9cBS%\xfa\xf7\xdb\x1a\x9a9\xd2\xf8;\xe5\xc1\xd8l\x16\xdeH?\xcd\xd7D\x9d\xcd\xc2\x1ej\xabb\x86\xa4u@\x9f\x1b\xe2}FtQ\xd9\x1f\xd7\xa4\xc1\xe8\x94N\n\xe9\xb2\xa0\xccD2\xe9)'
+
+    assert aes_decrypt(key, encrypted_data) == data
+
+
+def test_new_decrypt_function_can_process_old_data_with_v2_marker():
+    data = 'test'
+
+    # These were generated using the old encrypt functions.
+    # We make sure the new functions can still decypher the old
+    # encrypted data.
+    key = b'\xfe\xaf`\xa9UsC\xd5r\x00mm\x7f\x199\x96&]\xd6xI(*l\xb2\xe0\x9b\xb3&\\\x11\xe5\xcc\x9d\x92\xe8\x17)\x13\xf1\xcb\xf2=\xb6\x13Uv\xc6\x91\x1c@]\x8a\x91b\x07|\xb3\xa2\xb8\x8bJ\x88\xee'
+    encrypted_data = b'v21uM\xf7\x17\xd7\xa4\x167\xa0W\xf8<?\xde_\xc0@\xf6\x0c\xd21 Q\xbc1\xb9\xa9\xb8\x87\xd1x\xff\x86\x1e\xb5\xa6\x80\xa60\xaf^v\xc6\xba]ir\xd9\x9b\xfe7\xe0\xd46\xc0?\xb0\xa6n\xfe]\xcf\xacq '
+
+    assert aes_decrypt(key, encrypted_data) == data
+
+
+def test_new_decrypt_function_can_process_new_data():
+    data = 'test'
+    key = aes_generate_key()
+    assert aes_decrypt(key, aes_encrypt(key, data)) == data

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,4 +1,7 @@
-from flask_common.crypto import aes_encrypt, aes_decrypt, aes_generate_key
+import random
+import string
+
+from flask_common.crypto import aes_decrypt, aes_encrypt, aes_generate_key
 
 
 def test_new_decrypt_function_can_process_old_data():
@@ -26,6 +29,9 @@ def test_new_decrypt_function_can_process_old_data_with_v2_marker():
 
 
 def test_new_decrypt_function_can_process_new_data():
-    data = 'test'
     key = aes_generate_key()
-    assert aes_decrypt(key, aes_encrypt(key, data)) == data
+    char_choices = string.ascii_letters + string.digits
+
+    for length in range(1, 300):
+        data = ''.join(random.choice(char_choices) for x in range(length))
+        assert aes_decrypt(key, aes_encrypt(key, data)) == data


### PR DESCRIPTION
Closes https://github.com/closeio/flask-common/issues/63

**Technical details:**

We were encrypting using IVs with the wrong size, and `pycrypto` was silently truncating our IVs for us. `pycryptodome` won't do that for us. As a result, we now have to have two versions of encrypted things: the old ones are not marked with a version and have wrong size IVs that we have to fix before `pycryptodome` can process them, and the new ones are marked with `v2` at the start of the encrypted data string.

Then, we have to treat the edge case of an old data starting with `v2`, which will basically fail the decryption process because the IV with `v2` stripped out won't match, and then we try with the IV with `v2` in and in the old size.

There are tests to ensure we can seamlessly decrypt **old and new** encrypted data with these new functions.

The AES block size is always 16 bytes, as specified by NIST (source: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard), so I also renamed some variables to more meaningfully convey what they are used for.

**Why not the cryptography package as suggested in the issue?**

Because of this issue https://github.com/pyca/cryptography/issues/4020 that has been reported several times (has several duplicates in that repo) and has never been fixed. I've tried several ways to fix this from all duplicates, and nothing worked in my environment, at least. Then, I decided to evaluate if we could fork and fix this ourselves, but I think that would take too long and I decided to look for a different alternative. I found `pycryptodome`, which is a fork, in-place replacement, of `pycrypto`, that is currently maintained.

Repo: https://github.com/Legrandin/pycryptodome (last commit 20 days ago as of now)
Docs: https://pycryptodome.readthedocs.io/en/latest/