### PR TITLE
Fix Flask>=1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ workflows:
   workflow:
     jobs:
       - test-2.7
-      - test-3.4
       - test-3.5
       - test-3.6
       - test-3.7
@@ -30,11 +29,6 @@ jobs:
     <<: *defaults
     docker:
     - image: circleci/python:2.7
-    - image: mongo:3.2.19
-  test-3.4:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.4
     - image: mongo:3.2.19
   test-3.5:
     <<: *defaults

--- a/flask_common/client.py
+++ b/flask_common/client.py
@@ -13,8 +13,6 @@ from flask.testing import FlaskClient
 from six import PY3
 from werkzeug.datastructures import Headers
 
-from .utils import smart_unicode
-
 
 class Client(FlaskClient):
     """
@@ -31,14 +29,7 @@ class Client(FlaskClient):
             kwargs['data'] = json.dumps(kwargs.pop('json'))
             kwargs['content_type'] = 'application/json'
 
-        resp = super(Client, self).open(*args, **kwargs)
-
-        try:
-            resp.json = lambda: json.loads(smart_unicode(resp.data))
-        except ValueError:
-            pass
-
-        return resp
+        return super(Client, self).open(*args, **kwargs)
 
 
 class ApiClient(Client):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 future==0.17.1
 python-dateutil==2.5.0
 pytz==2015.7
-flask==0.10.1
+flask>=1
 -e git+ssh://git@github.com/closeio/mongoengine.git@7f0c4b85e375f4eb756932bcb6414daf7b993247#egg=mongoengine
 -e git+ssh://git@github.com/closeio/flask-mongoengine.git@0c2cc30ec98154bb2eb4499efada65239050025d#egg=flask-mongoengine
 Flask-SQLAlchemy==2.1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,3 +16,14 @@ def test_api_client_basic_auth():
 
     headers = client.get_headers(client.api_key)
     assert headers == Headers([('Authorization', 'Basic MTIzNDU2Og==',)])
+
+
+def test_json():
+    app = Flask('test')
+
+    @app.route('/', methods=['GET'])
+    def view():
+        return {'ok': 1}
+
+    client = ApiClient(app)
+    assert client.get('/').json['ok'] == 1

--- a/tests/test_mongo/test_documents.py
+++ b/tests/test_mongo/test_documents.py
@@ -53,6 +53,7 @@ class DocumentBaseTestCase(unittest.TestCase):
         last_date_created = doc.date_created
         last_date_updated = doc.date_updated
 
+        time.sleep(0.001)  # make sure some time passes between the updates
         doc.text = 'new'
         doc.save()
         doc.reload()


### PR DESCRIPTION
Two breaking changes:
- Test client's `.json()` is no longer a function but a flask-provided property, just `.json`. Will have to fix usages.
- Removed py3.4 (but it's EOL anyway).