### PR TITLE
Fix `fetch_related`'s behavior for broken references.

### DIFF
--- a/flask_common/mongo/utils.py
+++ b/flask_common/mongo/utils.py
@@ -313,8 +313,7 @@ def fetch_related(
                 val = getattr(obj, field_name, None)
                 if val and getattr(val, '_lazy', False):
                     rel_obj = pk_to_obj.get(val.pk)
-                    if rel_obj:
-                        setattr_unchanged(obj, field_name, rel_obj)
+                    setattr_unchanged(obj, field_name, rel_obj)
 
             elif isinstance(field, ListField):
                 if field_name not in obj._internal_data:


### PR DESCRIPTION
This is an attempt at fixing an issue where a broken reference of a `ReferenceField` is never resolved. I'm not 100% sure that it *always* makes sense to resolve broken references to `None`s, but I think it's worth considering.

Example usage:
```
In [1]: c = Call.objects.order_by('-date_created').first()

In [2]: from flask_common.mongo.utils import fetch_related

In [3]: fetch_related([c], {'transferred_from': {'user': True}})

In [4]: c.transferred_from

In [5]: # ^ W/o the change in this PR, this would raise a `DoesNotExist`.
```